### PR TITLE
Changing default settings to make cluster deployment easier

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,13 +72,12 @@ nsq_nsqd_e2e_processing_latency_window_time: 10m0s
 
 nsq_nsqlookupd_server: false
 nsq_nsqlookupd_user: nsqlookupd
-nsq_nsqlookupd_user: nsqlookupd
 nsq_nsqlookupd_role: nsqlookupd
 nsq_nsqlookupd_cmd: "{{ nsq_dir }}/nsqlookupd"
 nsq_nsqlookupd_tcp_port: 4160
 nsq_nsqlookupd_http_port: 4161
 nsq_nsqlookupd_interface: lo
-nsq_nsqlookupd_addr: "{{ hostvars[inventory_hostname]['ansible_' + nsq_nsqd_interface]['ipv4']['address'] }}"
+nsq_nsqlookupd_addr: "{{ hostvars[inventory_hostname]['ansible_' + nsq_nsqlookupd_interface]['ipv4']['address'] }}"
 nsq_nsqlookupd_http_address: "{{ nsq_nsqlookupd_addr }}:{{ nsq_nsqlookupd_http_port }}"
 nsq_nsqlookupd_inactive_producer_timeout: 5m0s
 nsq_nsqlookupd_tcp_address: "{{ nsq_nsqlookupd_addr }}:{{ nsq_nsqlookupd_tcp_port }}"

--- a/templates/etc/init/nsqd.conf.j2
+++ b/templates/etc/init/nsqd.conf.j2
@@ -25,7 +25,7 @@ script
     --data-path={{ nsq_nsqd_data_path }} \
     --http-address={{ nsq_nsqd_http_address }} \
     {% for host in groups[nsq_nsqlookupd_role] -%}
-      --lookupd-tcp-address={{ hostvars[host]['ansible_' + nsq_nsqd_interface]['ipv4']['address'] }}:{{ nsq_nsqlookupd_tcp_port }} \
+      --lookupd-tcp-address={{ hostvars[host]['ansible_' + nsq_nsqlookupd_interface]['ipv4']['address'] }}:{{ nsq_nsqlookupd_tcp_port }} \
     {% endfor -%}
     --e2e-processing-latency-percentile={{ nsq_nsqd_e2e_processing_latency_percentile }} \
     --e2e-processing-latency-window-time={{ nsq_nsqd_e2e_processing_latency_window_time }} \


### PR DESCRIPTION
Hiya -- thanks for this playbook.  It was quite useful.

I ran into some issues getting the cluster deployed as per the Readme.md, and eventually figured out that it was because nsqlookup and nsqd were listening to loopback rather than to eth0.  That's a sensible default choice for security, but the present configuration of the OSS playbook didn't flow overridden parameters correctly, so after fixing them internally I'm sending them upstream for your viewing edification.